### PR TITLE
Fix berks 7 dependencies resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .kitchen/
 .kitchen.local.yml
+.idea/

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ recipe           "openvas::openvasknife", "Install Perl cmd-line utility openvas
 recipe           "openvas::scan_single_target", "Used openvasknife to scan a target."
 recipe           "openvas::server", "Install the OpenVAS server."
 
-%w{ apt perl ark checkinstall ubuntu openvas }.each do |cb|
+%w{ apt perl ark checkinstall ubuntu }.each do |cb|
   depends cb
 end


### PR DESCRIPTION
Fixed dependencies resolution with Berks version 7.0.2 and higher when it fails with error:
RuntimeError: Cookbook depends on itself in cookbook openvas, please remove the this unnecessary self-dependency